### PR TITLE
[FIX] CSS in JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,7 @@
-# hello-vue-cli-5
+> Demo for fixing `SassError: This file is already being loaded.`
 
-## Project setup
-```
-npm install
-```
+https://stackoverflow.com/q/71709928/6277151
 
-### Compiles and hot-reloads for development
-```
-npm run serve
-```
+Components must avoid importing files that are already imported in the global variables stylesheet (`src/styles/variables.scss`). This was the case with `app.module.scss` (loaded in `src/styles/variables.scss` and in `src/components/HelloWorld.vue`), causing the error about the file being loaded twice.
 
-### Compiles and minifies for production
-```
-npm run build
-```
-
-### Run your end-to-end tests
-```
-npm run test:e2e
-```
-
-### Lints and fixes files
-```
-npm run lint
-```
-
-### Customize configuration
-See [Configuration Reference](https://cli.vuejs.org/config/).
+One solution is to move the color definitions from `app.module.scss` into its own file, and import that in `variables.scss` instead of `app.module.scss`. Then, components could import `app.mdoule.scss` without running into the original problem.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8134,16 +8134,49 @@
       }
     },
     "sass-loader": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-8.0.2.tgz",
-      "integrity": "sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-10.2.1.tgz",
+      "integrity": "sha512-RRvWl+3K2LSMezIsd008ErK4rk6CulIMSwrcc2aZvjymUgKo/vjXGp1rSWmfTUX7bblEOz8tst4wBwWtCGBqKA==",
       "dev": true,
       "requires": {
-        "clone-deep": "^4.0.1",
-        "loader-utils": "^1.2.3",
-        "neo-async": "^2.6.1",
-        "schema-utils": "^2.6.1",
-        "semver": "^6.3.0"
+        "klona": "^2.0.4",
+        "loader-utils": "^2.0.0",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^3.0.0",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "schema-utils": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "schema-utils": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint-staged": "^11.1.2",
     "prettier": "^2.4.1",
     "sass": "~1.32.0",
-    "sass-loader": "^8.0.0",
+    "sass-loader": "^10.0.0",
     "vue-cli-plugin-vuetify": "~2.4.5",
     "vue-template-compiler": "^2.6.14",
     "vuetify-loader": "^1.7.3"

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,7 @@
 <template>
   <v-app>
     <v-app-bar app color="primary" dark>
+      <MyHeader>Hello world</MyHeader>
       <div class="d-flex align-center">
         <v-img
           alt="Vuetify Logo"
@@ -40,9 +41,13 @@
 </template>
 
 <script>
+import MyHeader from "@/components/MyHeader.vue";
+
 export default {
   name: "App",
-
+  components: {
+    MyHeader,
+  },
   data: () => ({
     //
   }),

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -79,7 +79,7 @@
 </template>
 
 <script>
-import { alertcolor } from "@/styles/app.module.scss";
+import style from "@/styles/app.module.scss";
 
 export default {
   name: "HelloWorld",
@@ -137,7 +137,7 @@ export default {
     ],
   }),
   created() {
-    this.alertcolor = alertcolor;
+    this.alertcolor = style.alertcolor;
   },
 };
 </script>

--- a/src/components/MyHeader.vue
+++ b/src/components/MyHeader.vue
@@ -1,0 +1,15 @@
+<template>
+  <h2 :style="{ color: mediumcolor }"><slot /></h2>
+</template>
+
+<script>
+import { mediumcolor } from "@/styles/app.module.scss";
+
+export default {
+  data() {
+    return {
+      mediumcolor,
+    };
+  },
+};
+</script>

--- a/src/components/MyHeader.vue
+++ b/src/components/MyHeader.vue
@@ -3,12 +3,12 @@
 </template>
 
 <script>
-import { mediumcolor } from "@/styles/app.module.scss";
+import style from "@/styles/app.module.scss";
 
 export default {
   data() {
     return {
-      mediumcolor,
+      mediumcolor: style.mediumcolor,
     };
   },
 };

--- a/src/plugins/vuetify.js
+++ b/src/plugins/vuetify.js
@@ -2,8 +2,8 @@ import Vue from "vue";
 import Vuetify from "vuetify/lib/framework";
 
 // eslint-disable-next-line no-unused-vars
-import appStyles from "@/styles/app.module.scss";
-console.log(appStyles);
+import style from "@/styles/app.module.scss";
+console.log(style);
 
 Vue.use(Vuetify);
 

--- a/src/styles/app.module.scss
+++ b/src/styles/app.module.scss
@@ -1,11 +1,3 @@
-$white-color: #fcf5ed;
-$dark-color: #402f2b;
-$light-color: #e6d5c3;
-$medium-color: #977978;
-$alert-color: #cb492a;
-$light-black-color: #706e72;
-$black-color: #414042;
-
 :export {
   whitecolor: $white-color;
   darkcolor: $dark-color;

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -1,0 +1,7 @@
+$white-color: #fcf5ed;
+$dark-color: #402f2b;
+$light-color: #e6d5c3;
+$medium-color: #977978;
+$alert-color: #cb492a;
+$light-black-color: #706e72;
+$black-color: #414042;

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1,5 +1,5 @@
 @import "~vuetify/src/styles/settings/_colors.scss";
-@import "app.module.scss";
+@import "colors.scss";
 
 $material-light: (
   background: map-get($grey, "lighten-1")


### PR DESCRIPTION
Following https://github.com/KevinFabre/vue-cli-5-vuetify-scss-variables-in-js/pull/1

Update how CSS is imported in JS.

Always import the full object.
When NODE_ENV = production, only the default export can be imported.